### PR TITLE
Work around gettimeofday being non-monotonic.

### DIFF
--- a/utils/datetime.cpp
+++ b/utils/datetime.cpp
@@ -590,11 +590,12 @@ datetime::timestamp::operator-=(const datetime::delta& other)
 datetime::delta
 datetime::timestamp::operator-(const datetime::timestamp& other) const
 {
-    if ((*this) < other) {
-        throw std::runtime_error(
-            F("Cannot subtract %s from %s as it would result in a negative "
-              "datetime::delta, which are not supported") % other % (*this));
-    }
+    /*
+     * XXX-BD: gettimeofday isn't necessarily monotonic so return the
+     * smallest non-zero delta if time went backwards.
+     */
+    if ((*this) < other)
+        return datetime::delta::from_microseconds(1);
     return datetime::delta::from_microseconds(to_microseconds() -
                                               other.to_microseconds());
 }

--- a/utils/datetime_test.cpp
+++ b/utils/datetime_test.cpp
@@ -532,11 +532,11 @@ ATF_TEST_CASE_BODY(timestamp__subtraction)
     ATF_REQUIRE_EQ(datetime::delta(100, 0), ts3 - ts1);
     ATF_REQUIRE_EQ(datetime::delta(99, 999988), ts3 - ts2);
 
-    ATF_REQUIRE_THROW_RE(
-        std::runtime_error,
-        "Cannot subtract 1291970850123456us from 1291970750123468us "
-        ".*negative datetime::delta.*not supported",
-        ts2 - ts3);
+    /*
+     * NOTE (ngie): behavior change for
+     * https://github.com/jmmv/kyua/issues/155 .
+     */
+    ATF_REQUIRE_EQ(datetime::delta::from_microseconds(1), ts2 - ts3);
 }
 
 


### PR DESCRIPTION
The computer's concept of "now" can go backwards (and does so with
regularity in QEMU MIPS). If two timestamps are mis-ordered, just
return a 1ms delta.

See also: https://github.com/jmmv/kyua/issues/155

Test fix sumitted by: @ngie-eign