### PR TITLE
Update authorship

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,4 +8,5 @@
 #     * Name <email address>
 #     * Organization <optional email address>
 
+* The FreeBSD Foundation
 * Google Inc.

--- a/doc/kyua.1.in
+++ b/doc/kyua.1.in
@@ -392,6 +392,11 @@ codes above 1 can be returned.
 .Xr atf 7 ,
 .Xr tests 7
 .Sh AUTHORS
+The original author of
+.Nm
+was
+.An Julio Merino .
+.Pp
 For more details on the people that made
 .Nm
 possible and the license terms, run:


### PR DESCRIPTION
This change references Julio Merino as the primary author of kyua, while also referencing additional contributors and sponsors that have help authored the kyua test framework via `kyua about`. This fixes `mandoc -T manlint` by side-effect.

While here, also mention that the FreeBSD Foundation has contributed to the development of kyua. Some of the authors, e.g., Ed Maste, have contributed with the financial backing of FreeBSD Foundation.